### PR TITLE
fix(store): exclude cloud-rejected rows from mutation backfill

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5075,8 +5075,17 @@ func (s *Store) projectNeedsBackfill(project string) (bool, error) {
 	}
 	queries := []countQuery{
 		{
+			// Cloud validation hard-rejects a session upsert whose directory is
+			// still empty after inferring it from the live row (see
+			// evaluateCloudUpgradeLegacyMutationTx). Backfilling such a row would
+			// enqueue a mutation the server is certain to reject; since
+			// repairEnrolledProjectSyncMutations runs on every store open, the
+			// rejected mutation would be re-enqueued forever. Exclude it from
+			// both the count and the backfill — this predicate must stay
+			// identical to the SELECT in backfillSessionSyncMutationsTx.
 			q: `SELECT COUNT(*) FROM sessions
 			    WHERE project = ?
+			      AND trim(ifnull(directory, '')) != ''
 			      AND NOT EXISTS (
 			        SELECT 1 FROM sync_mutations sm
 			        WHERE sm.target_key = ? AND sm.entity = ? AND sm.entity_key = sessions.id AND sm.source = ?
@@ -5084,10 +5093,19 @@ func (s *Store) projectNeedsBackfill(project string) (bool, error) {
 			args: []any{project, DefaultSyncTargetKey, SyncEntitySession, SyncSourceLocal},
 		},
 		{
+			// Same principle as above, for the observation upsert fields cloud
+			// validation requires (session_id, type, title, content, scope).
+			// This predicate must stay identical to the SELECT in
+			// backfillObservationSyncMutationsTx's live-observations query.
 			q: `SELECT COUNT(*) FROM observations o
 			    LEFT JOIN sessions s ON s.id = o.session_id
 			    WHERE (ifnull(o.project,'') = ? OR (ifnull(o.project,'') = '' AND ifnull(s.project,'') = ?))
 			      AND o.deleted_at IS NULL
+			      AND trim(ifnull(o.session_id, '')) != ''
+			      AND trim(ifnull(o.type, '')) != ''
+			      AND trim(ifnull(o.title, '')) != ''
+			      AND trim(ifnull(o.content, '')) != ''
+			      AND trim(ifnull(o.scope, '')) != ''
 			      AND NOT EXISTS (
 			        SELECT 1 FROM sync_mutations sm
 			        WHERE sm.target_key = ? AND sm.entity = ? AND sm.entity_key = o.sync_id AND sm.source = ?
@@ -5095,9 +5113,15 @@ func (s *Store) projectNeedsBackfill(project string) (bool, error) {
 			args: []any{project, project, DefaultSyncTargetKey, SyncEntityObservation, SyncSourceLocal},
 		},
 		{
+			// Same principle as above, for the prompt upsert fields cloud
+			// validation requires (session_id, content). This predicate must
+			// stay identical to the SELECT in backfillPromptSyncMutationsTx's
+			// live-prompts query.
 			q: `SELECT COUNT(*) FROM user_prompts p
 			    LEFT JOIN sessions s ON s.id = p.session_id
 			    WHERE (ifnull(p.project,'') = ? OR (ifnull(p.project,'') = '' AND ifnull(s.project,'') = ?))
+			      AND trim(ifnull(p.session_id, '')) != ''
+			      AND trim(ifnull(p.content, '')) != ''
 			      AND NOT EXISTS (
 			        SELECT 1 FROM sync_mutations sm
 			        WHERE sm.target_key = ? AND sm.entity = ? AND sm.entity_key = p.sync_id AND sm.source = ?
@@ -5182,10 +5206,15 @@ func (s *Store) repairEnrolledProjectSyncMutations() error {
 }
 
 func (s *Store) backfillSessionSyncMutationsTx(tx *sql.Tx, project string) error {
+	// See the matching comment on the session COUNT query in projectNeedsBackfill:
+	// a session with an empty directory is certain to be rejected by cloud
+	// validation, so it is excluded here too to avoid enqueueing an
+	// undeliverable mutation that would just be re-created on the next backfill.
 	rows, err := s.queryItHook(tx, `
 		SELECT id, project, directory, started_at, ended_at, summary
 		FROM sessions
 		WHERE project = ?
+		  AND trim(ifnull(directory, '')) != ''
 		  AND NOT EXISTS (
 			SELECT 1
 			FROM sync_mutations sm
@@ -5231,6 +5260,11 @@ func (s *Store) backfillSessionSyncMutationsTx(tx *sql.Tx, project string) error
 
 func (s *Store) backfillObservationSyncMutationsTx(tx *sql.Tx, project string) error {
 	// ── Live observations ─────────────────────────────────────────────────────
+	// See the matching comment on the observation COUNT query in
+	// projectNeedsBackfill: an observation still missing any of the cloud's
+	// required upsert fields (session_id, type, title, content, scope) is
+	// excluded here too, otherwise every store open would re-enqueue a
+	// mutation the server is certain to reject.
 	rows, err := s.queryItHook(tx, `
 		SELECT o.sync_id, o.session_id, o.type, o.title, o.content, o.tool_name, o.project, o.scope, o.topic_key,
 		       o.revision_count, o.duplicate_count, o.last_seen_at, o.created_at, o.updated_at
@@ -5241,6 +5275,11 @@ func (s *Store) backfillObservationSyncMutationsTx(tx *sql.Tx, project string) e
 			OR (ifnull(o.project, '') = '' AND ifnull(s.project, '') = ?)
 		)
 		  AND deleted_at IS NULL
+		  AND trim(ifnull(o.session_id, '')) != ''
+		  AND trim(ifnull(o.type, '')) != ''
+		  AND trim(ifnull(o.title, '')) != ''
+		  AND trim(ifnull(o.content, '')) != ''
+		  AND trim(ifnull(o.scope, '')) != ''
 		  AND NOT EXISTS (
 			SELECT 1
 			FROM sync_mutations sm
@@ -5349,6 +5388,10 @@ func (s *Store) backfillObservationSyncMutationsTx(tx *sql.Tx, project string) e
 
 func (s *Store) backfillPromptSyncMutationsTx(tx *sql.Tx, project string) error {
 	// ── Live prompts ──────────────────────────────────────────────────────────
+	// See the matching comment on the prompt COUNT query in
+	// projectNeedsBackfill: a prompt still missing session_id or content is
+	// excluded here too, otherwise every store open would re-enqueue a
+	// mutation the server is certain to reject.
 	rows, err := s.queryItHook(tx, `
 		SELECT p.sync_id, p.session_id, p.content, p.project, p.created_at
 		FROM user_prompts p
@@ -5357,6 +5400,8 @@ func (s *Store) backfillPromptSyncMutationsTx(tx *sql.Tx, project string) error 
 			ifnull(p.project, '') = ?
 			OR (ifnull(p.project, '') = '' AND ifnull(s.project, '') = ?)
 		)
+		  AND trim(ifnull(p.session_id, '')) != ''
+		  AND trim(ifnull(p.content, '')) != ''
 		  AND NOT EXISTS (
 			SELECT 1
 			FROM sync_mutations sm

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7724,6 +7724,184 @@ func TestRepairHandlesMixedState(t *testing.T) {
 	}
 }
 
+// TestRepairDoesNotBackfillObservationsCloudWouldReject verifies that an
+// observation still missing a cloud-required upsert field (session_id, type,
+// title, content, or scope — see evaluateCloudUpgradeLegacyMutationTx) is
+// never backfilled into a sync_mutations row, while a fully-valid observation
+// in the same project is. Without the valid-row assertion, a backfill that
+// skips every observation would also satisfy a check that only asserts the
+// invalid row stays unqueued.
+func TestRepairDoesNotBackfillObservationsCloudWouldReject(t *testing.T) {
+	s := newTestStoreRaw(t)
+
+	if _, err := s.db.Exec(`INSERT OR IGNORE INTO sync_enrolled_projects (project) VALUES (?)`, "engram"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, datetime('now'))`,
+		"s-mixed-obs", "engram", "/tmp/engram",
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	emptyContentSync := "obs-empty-content"
+	if _, err := s.db.Exec(`
+		INSERT INTO observations (session_id, type, title, content, project, scope, normalized_hash,
+		                          revision_count, duplicate_count, last_seen_at, updated_at, sync_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), datetime('now'), ?)`,
+		"s-mixed-obs", "decision", "Has a title", "", "engram", "project", hashNormalized(""), emptyContentSync,
+	); err != nil {
+		t.Fatalf("insert observation with empty content: %v", err)
+	}
+
+	validSync := "obs-valid-001"
+	if _, err := s.db.Exec(`
+		INSERT INTO observations (session_id, type, title, content, project, scope, normalized_hash,
+		                          revision_count, duplicate_count, last_seen_at, updated_at, sync_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1, datetime('now'), datetime('now'), ?)`,
+		"s-mixed-obs", "decision", "T", "C", "engram", "project", hashNormalized("C"), validSync,
+	); err != nil {
+		t.Fatalf("insert valid observation: %v", err)
+	}
+
+	if err := s.repairEnrolledProjectSyncMutations(); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+
+	var emptyCount int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`,
+		SyncEntityObservation, emptyContentSync, SyncSourceLocal,
+	).Scan(&emptyCount); err != nil {
+		t.Fatalf("count empty-content observation mutations: %v", err)
+	}
+	if emptyCount != 0 {
+		t.Fatalf("expected the empty-content observation to stay unqueued, got %d mutation(s)", emptyCount)
+	}
+
+	var validCount int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`,
+		SyncEntityObservation, validSync, SyncSourceLocal,
+	).Scan(&validCount); err != nil {
+		t.Fatalf("count valid observation mutations: %v", err)
+	}
+	if validCount == 0 {
+		t.Fatalf("expected the valid observation to be backfilled, got 0 mutations")
+	}
+}
+
+// TestRepairDoesNotBackfillPromptsCloudWouldReject mirrors
+// TestRepairDoesNotBackfillObservationsCloudWouldReject for prompts: a prompt
+// with empty content stays unqueued, a prompt with real content is backfilled.
+func TestRepairDoesNotBackfillPromptsCloudWouldReject(t *testing.T) {
+	s := newTestStoreRaw(t)
+
+	if _, err := s.db.Exec(`INSERT OR IGNORE INTO sync_enrolled_projects (project) VALUES (?)`, "engram"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, datetime('now'))`,
+		"s-mixed-prompt", "engram", "/tmp/engram",
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	emptyContentSync := "prompt-empty-content"
+	if _, err := s.db.Exec(`
+		INSERT INTO user_prompts (session_id, content, project, created_at, sync_id)
+		VALUES (?, ?, ?, datetime('now'), ?)`,
+		"s-mixed-prompt", "", "engram", emptyContentSync,
+	); err != nil {
+		t.Fatalf("insert prompt with empty content: %v", err)
+	}
+
+	validSync := "prompt-valid-001"
+	if _, err := s.db.Exec(`
+		INSERT INTO user_prompts (session_id, content, project, created_at, sync_id)
+		VALUES (?, ?, ?, datetime('now'), ?)`,
+		"s-mixed-prompt", "hello", "engram", validSync,
+	); err != nil {
+		t.Fatalf("insert valid prompt: %v", err)
+	}
+
+	if err := s.repairEnrolledProjectSyncMutations(); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+
+	var emptyCount int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`,
+		SyncEntityPrompt, emptyContentSync, SyncSourceLocal,
+	).Scan(&emptyCount); err != nil {
+		t.Fatalf("count empty-content prompt mutations: %v", err)
+	}
+	if emptyCount != 0 {
+		t.Fatalf("expected the empty-content prompt to stay unqueued, got %d mutation(s)", emptyCount)
+	}
+
+	var validCount int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`,
+		SyncEntityPrompt, validSync, SyncSourceLocal,
+	).Scan(&validCount); err != nil {
+		t.Fatalf("count valid prompt mutations: %v", err)
+	}
+	if validCount == 0 {
+		t.Fatalf("expected the valid prompt to be backfilled, got 0 mutations")
+	}
+}
+
+// TestRepairDoesNotBackfillSessionsCloudWouldReject mirrors
+// TestRepairDoesNotBackfillObservationsCloudWouldReject for sessions: a
+// session with an empty directory stays unqueued, a session with a real
+// directory is backfilled.
+func TestRepairDoesNotBackfillSessionsCloudWouldReject(t *testing.T) {
+	s := newTestStoreRaw(t)
+
+	if _, err := s.db.Exec(`INSERT OR IGNORE INTO sync_enrolled_projects (project) VALUES (?)`, "engram"); err != nil {
+		t.Fatalf("enroll project: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, datetime('now'))`,
+		"s-empty-directory", "engram", "", // empty directory
+	); err != nil {
+		t.Fatalf("insert session with empty directory: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO sessions (id, project, directory, started_at) VALUES (?, ?, ?, datetime('now'))`,
+		"s-valid-directory", "engram", "/tmp/engram",
+	); err != nil {
+		t.Fatalf("insert valid session: %v", err)
+	}
+
+	if err := s.repairEnrolledProjectSyncMutations(); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+
+	var emptyCount int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`,
+		SyncEntitySession, "s-empty-directory", SyncSourceLocal,
+	).Scan(&emptyCount); err != nil {
+		t.Fatalf("count empty-directory session mutations: %v", err)
+	}
+	if emptyCount != 0 {
+		t.Fatalf("expected the empty-directory session to stay unqueued, got %d mutation(s)", emptyCount)
+	}
+
+	var validCount int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM sync_mutations WHERE entity = ? AND entity_key = ? AND source = ?`,
+		SyncEntitySession, "s-valid-directory", SyncSourceLocal,
+	).Scan(&validCount); err != nil {
+		t.Fatalf("count valid session mutations: %v", err)
+	}
+	if validCount == 0 {
+		t.Fatalf("expected the valid session to be backfilled, got 0 mutations")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Phase F — Decay defaults wiring (REQ-006)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The backfill that runs on every store open re-enqueues any local row of an
enrolled project that has no `source=local` mutation. When the row is missing a
field that cloud validation requires, the enqueued mutation is certain to be
rejected — and because the backfill runs again on the next store open, the same
undeliverable mutation comes straight back. A project in that state can never
drain, and deleting the mutation does not help: the next `engram` invocation
recreates it.

`backfillRelationSyncMutationsTx` already guards against exactly this, and says
why in its own comment: pending relations "would be rejected by cloud validation
(HTTP 400), so we exclude them from both the count and the backfill to avoid
polluting the sync journal with undeliverable mutations". Sessions, observations
and prompts did not get that treatment. This extends the existing rule to them.

The excluded fields are the ones `evaluateCloudUpgradeLegacyMutationTx` requires
after it has tried to derive them from the live row: `directory` for a session;
`session_id`, `type`, `title`, `content` and `scope` for an observation;
`session_id` and `content` for a prompt. Rows that only lack a field the live
row can supply stay eligible, so the repair path is untouched.

Each predicate is added on both sides of its entity — the `COUNT(*)` fast path
in `projectNeedsBackfill` and the write `SELECT` in the corresponding
`backfill*SyncMutationsTx` — because a divergence between the two desyncs the
skip check from the write path. The delete branches are left alone: they carry
no payload fields to validate.

## Verification

Three tests, one per entity, each pairing an invalid row that must stay unqueued
with a valid row that must still be enqueued — without the positive case a
backfill that enqueued nothing at all would pass.

Applying only the test changes on top of the parent commit fails all three:

```
--- FAIL: TestRepairDoesNotBackfillObservationsCloudWouldReject
    expected the empty-content observation to stay unqueued, got 1 mutation(s)
--- FAIL: TestRepairDoesNotBackfillPromptsCloudWouldReject
--- FAIL: TestRepairDoesNotBackfillSessionsCloudWouldReject
```

With the fix the three pass and `go test ./...` is green across the module. The
four existing tests that exercise `repairEnrolledProjectSyncMutations` use
non-empty fixtures, so none of them fall inside the new exclusion and none
needed changing.